### PR TITLE
Phase 1 & 4: Layout Foundation + Stats Sidebar

### DIFF
--- a/frontend/src/Pages/Home/HomeLanding.tsx
+++ b/frontend/src/Pages/Home/HomeLanding.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StatsHeader } from '@/components/StatsHeader';
+import { StatsSidebar } from '@/components/StatsSidebar/StatsSidebar';
 import './HomeLanding.css';
 
 const HomeLanding: React.FC = () => {
@@ -17,13 +18,7 @@ const HomeLanding: React.FC = () => {
           </div>
         </main>
         <aside className="right-sidebar">
-          <div className="placeholder">
-            <h3>📊 Daily Stats</h3>
-            <p>Coming soon in Phase 3!</p>
-            <p style={{ color: '#999', fontSize: '14px' }}>
-              Daily quests, league rankings, and friend activity will appear here.
-            </p>
-          </div>
+          <StatsSidebar />
         </aside>
       </div>
     </div>

--- a/frontend/src/components/StatsSidebar/DailyQuests.css
+++ b/frontend/src/components/StatsSidebar/DailyQuests.css
@@ -1,0 +1,38 @@
+/* Daily Quests */
+.daily-quests {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.quests-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.quests-header h3 {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.view-all-btn {
+  background: none;
+  border: none;
+  color: #06b6d4;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.view-all-btn:hover {
+  color: #0891b2;
+}
+
+.quests-list {
+  display: flex;
+  flex-direction: column;
+}

--- a/frontend/src/components/StatsSidebar/DailyQuests.tsx
+++ b/frontend/src/components/StatsSidebar/DailyQuests.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { QuestItem } from './QuestItem';
+import './DailyQuests.css';
+
+export const DailyQuests: React.FC = () => {
+  const quests = [
+    { icon: '⚡', description: 'Earn 30 XP', progress: 30, target: 30, completed: true },
+    { icon: '🔥', description: 'Get 5 in a row correct in 2 lessons', progress: 2, target: 2, completed: true },
+    { icon: '🎯', description: 'Complete 3 perfect lessons', progress: 2, target: 3, completed: false },
+  ];
+
+  return (
+    <div className="daily-quests">
+      <div className="quests-header">
+        <h3>Daily Quests</h3>
+        <button className="view-all-btn">VIEW ALL</button>
+      </div>
+
+      <div className="quests-list">
+        {quests.map((quest, i) => (
+          <QuestItem key={i} {...quest} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/StatsSidebar/LeaguePanel.css
+++ b/frontend/src/components/StatsSidebar/LeaguePanel.css
@@ -1,0 +1,82 @@
+/* League Panel */
+.league-panel {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.league-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 16px;
+  margin-top: 0;
+}
+
+.rank-display {
+  margin-bottom: 16px;
+}
+
+.rank-badge {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: linear-gradient(135deg, #a855f7 0%, #ec4899 100%);
+  border-radius: 12px;
+  color: white;
+}
+
+.badge-icon {
+  font-size: 32px;
+}
+
+.rank-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.rank-label {
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+.rank-number {
+  font-size: 24px;
+  font-weight: 700;
+  color: #10b981;
+}
+
+.rank-change {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: #dcfce7;
+  border-radius: 8px;
+  color: #16a34a;
+  font-size: 14px;
+}
+
+.check-icon {
+  font-weight: 700;
+}
+
+.view-league-btn {
+  width: 100%;
+  margin-top: 16px;
+  padding: 12px;
+  background: #06b6d4;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.view-league-btn:hover {
+  background: #0891b2;
+}

--- a/frontend/src/components/StatsSidebar/LeaguePanel.tsx
+++ b/frontend/src/components/StatsSidebar/LeaguePanel.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import './LeaguePanel.css';
+
+export const LeaguePanel: React.FC = () => {
+  return (
+    <div className="league-panel">
+      <h3 className="league-title">Pearl League</h3>
+
+      <div className="rank-display">
+        <div className="rank-badge">
+          <div className="badge-icon">💎</div>
+          <div className="rank-info">
+            <span className="rank-label">You're ranked</span>
+            <span className="rank-number">#1</span>
+          </div>
+        </div>
+
+        <div className="rank-change">
+          <span className="check-icon">✓</span>
+          <span>You moved up 1 rank!</span>
+        </div>
+      </div>
+
+      <button className="view-league-btn">VIEW LEAGUE</button>
+    </div>
+  );
+};

--- a/frontend/src/components/StatsSidebar/QuestItem.css
+++ b/frontend/src/components/StatsSidebar/QuestItem.css
@@ -1,0 +1,63 @@
+/* Quest Item */
+.quest-item {
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  border: 2px solid #e5e5e5;
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+
+.quest-item:last-child {
+  margin-bottom: 0;
+}
+
+.quest-item.completed {
+  opacity: 0.6;
+  background: #f9fafb;
+}
+
+.quest-icon {
+  font-size: 24px;
+}
+
+.quest-content {
+  flex: 1;
+}
+
+.quest-description {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+}
+
+.progress-bar-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.progress-bar-bg {
+  height: 12px;
+  background: #e5e5e5;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: #fbbf24;
+  border-radius: 6px;
+  transition: width 0.3s ease;
+}
+
+.progress-text {
+  font-size: 12px;
+  color: #666;
+}
+
+.quest-reward {
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+}

--- a/frontend/src/components/StatsSidebar/QuestItem.tsx
+++ b/frontend/src/components/StatsSidebar/QuestItem.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import './QuestItem.css';
+
+interface QuestItemProps {
+  icon: string;
+  description: string;
+  progress: number;
+  target: number;
+  completed: boolean;
+}
+
+export const QuestItem: React.FC<QuestItemProps> = ({
+  icon,
+  description,
+  progress,
+  target,
+  completed
+}) => {
+  const percentage = (progress / target) * 100;
+
+  return (
+    <div className={`quest-item${completed ? ' completed' : ''}`}>
+      <div className="quest-icon">{icon}</div>
+
+      <div className="quest-content">
+        <p className="quest-description">{description}</p>
+
+        <div className="progress-bar-container">
+          <div className="progress-bar-bg">
+            <div
+              className="progress-bar-fill"
+              style={{ width: `${percentage}%` }}
+            />
+          </div>
+          <span className="progress-text">{progress} / {target}</span>
+        </div>
+      </div>
+
+      <div className="quest-reward">
+        {completed ? '✓' : '🎁'}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/StatsSidebar/StatsSidebar.css
+++ b/frontend/src/components/StatsSidebar/StatsSidebar.css
@@ -1,0 +1,6 @@
+/* Stats Sidebar Container */
+.stats-sidebar-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/frontend/src/components/StatsSidebar/StatsSidebar.tsx
+++ b/frontend/src/components/StatsSidebar/StatsSidebar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { LeaguePanel } from './LeaguePanel';
+import { DailyQuests } from './DailyQuests';
+import './StatsSidebar.css';
+
+export const StatsSidebar: React.FC = () => {
+  return (
+    <div className="stats-sidebar-container">
+      <LeaguePanel />
+      <DailyQuests />
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Phase 1: Persistent left icon nav (60px), new HomeLanding with StatsHeader, 2-col grid layout
- Phase 4: Right sidebar with LeaguePanel and DailyQuests components
- Removed PillNavigation, archived old Home.tsx
- Route change: /worldmap → /world-map
- Added 5 placeholder pages: Practice, Leaderboards, Quests, Profile, More

## Related Issues
Closes #22 (Phase 1)
Closes #25 (Phase 4)

## Changes
**Phase 1:**
- LeftIconNav with 9 Lucide icons, instant tooltips
- StatsHeader with hardcoded stats (12 hearts, 295 flames, 3091 gems, #1 rank)
- HomeLanding with 2-column grid (1fr | 300px)
- Organized pages into Pages/ folder structure
- App-level layout with persistent sidebar

**Phase 4:**
- LeaguePanel (Pearl League, rank #1, "moved up 1 rank!")
- DailyQuests with 3 hardcoded quests
- QuestItem with dynamic progress bars
- Separated CSS files per component

🤖 Generated with [Claude Code](https://claude.com/claude-code)